### PR TITLE
fix: Update UI naming per Obsidian code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Obsidian `@People`
+# At People
 
 Obsidian plugin to add that familiar @-to-tag-someone syntax:
 

--- a/main.js
+++ b/main.js
@@ -585,7 +585,7 @@ class AtPeopleSettingTab extends PluginSettingTab {
 				})
 			)
 		new Setting(containerEl)
-			.setName('Folder Mode')
+			.setName('Folder mode')
 			.setDesc(multiLineDesc([
 			"Default - Creates a file for every person in the path defined in \"People folder\" e.g. [[People/@Bob Dole|@Bob Dole]]",
 			"",
@@ -596,8 +596,8 @@ class AtPeopleSettingTab extends PluginSettingTab {
 			.addDropdown(
 				dropdown => {
 					dropdown.addOption("DEFAULT", "Default");
-					dropdown.addOption("PER_PERSON", "Per Person");
-					dropdown.addOption("PER_LASTNAME", "Per Lastname");
+					dropdown.addOption("PER_PERSON", "Per person");
+					dropdown.addOption("PER_LASTNAME", "Per lastname");
 					dropdown.setValue(this.plugin.settings.folderMode)
 					dropdown.onChange(async (value) => {
 						this.plugin.settings.folderMode = value

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "at-people",
   "name": "At People",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Use the @ to create links to people files with smart fuzzy search, accent-insensitive matching, and backlink-based ranking.",
   "author": "Yass Fuentes (originally saibotsivad)",
   "authorUrl": "https://github.com/backmind/obsidian-at-people",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-at-people",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Use the @ to create links to people files with smart fuzzy search, accent-insensitive matching, and backlink-based ranking.",
   "main": "main.js",
   "repository": {


### PR DESCRIPTION
- Change README title from "Obsidian \`@People\`" to "At People"
- Change settings "Folder Mode" to "Folder mode"
- Change dropdown options "Per Person" and "Per Lastname" to lowercase
- Bump version to 1.2.2

Fixes #3