### PR TITLE
feat: add CSS hooks and optional pill styling for person links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A lightweight Obsidian plugin that lets you mention people with `@`, just like y
 - **Dismiss with Escape** — press `Esc` to dismiss suggestions; they won't reappear until you type a new `@`
 - **Auto-create files** — optionally create person files and folders on the fly when selecting a suggestion
 - **Flexible folder modes** — store people as flat files, per-person folders, or grouped by last name
+- **Styleable links**: person links get the `at-person` CSS class and a `data-at-person` attribute in Reading view, so you can format them with your own CSS (e.g. as `@`-pills); an optional built-in pill style is included
 
 ## Installation
 
@@ -109,6 +110,42 @@ Typing `@Mary` or `@mamá` will suggest **María García**. The suggestion shows
 ### Require @ prefix
 
 Enabled by default. When enabled, only files starting with `@` are recognized as people. When disabled, all `.md` files in the people folder are treated as people. See [file naming](#important-file-naming) for details.
+
+### Style person links as pills
+
+Disabled by default. When enabled, person links are shown as tag-style pills in Reading view, reusing your theme's tag colors (a pill with `@` instead of `#`). Prefer your own look? See [Styling person links](#styling-person-links) below.
+
+## Styling person links
+
+In Reading (Preview) view, every person link receives:
+
+- the CSS class `at-person`
+- a `data-at-person="<name>"` attribute holding the person's name (without the `@` prefix)
+
+This lets you target person links from your own CSS snippet or theme. For example, to render them as pills with `@` instead of `#`:
+
+```css
+.at-person {
+	background-color: var(--tag-background);
+	color: var(--tag-color);
+	font-size: var(--tag-size);
+	padding: var(--tag-padding-y) var(--tag-padding-x);
+	border-radius: var(--tag-radius);
+	text-decoration: none;
+}
+```
+
+To style a specific person, use the data attribute:
+
+```css
+.at-person[data-at-person="Jane Doe"] {
+	color: var(--color-red);
+}
+```
+
+Don't want to write CSS? Enable **Style person links as pills** in settings for a built-in version of the look above.
+
+> **Note:** styling applies in Reading (Preview) view. Live Preview (edit mode) is not styled yet.
 
 ## How ranking works
 

--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const DEFAULT_SETTINGS = {
 	autoCreateFiles: false,
 	requireAtPrefix: true,
 	useAliases: false,
+	enablePillStyle: false,
 }
 
 // Regex to extract person name from file path
@@ -51,6 +52,7 @@ const getPersonName = (filename, settings) => {
 module.exports = class AtPeople extends Plugin {
 	async onload() {
 		await this.loadSettings()
+		this.applyPillStyleClass()
 		this.registerEvent(this.app.vault.on('delete', async event => { await this.update(event) }))
 		this.registerEvent(this.app.vault.on('create', async event => { await this.update(event) }))
 		this.registerEvent(this.app.vault.on('rename', async (event, originalFilepath) => { await this.update(event, originalFilepath) }))
@@ -58,6 +60,9 @@ module.exports = class AtPeople extends Plugin {
 		this.addSettingTab(new AtPeopleSettingTab(this.app, this))
 		this.suggestor = new AtPeopleSuggestor(this.app, this)
 		this.registerEditorSuggest(this.suggestor)
+
+		// Tag person links in Reading view so they can be targeted with CSS.
+		this.registerMarkdownPostProcessor((el, ctx) => this.markPersonLinks(el, ctx.sourcePath))
 		
 		// Command to convert selected text into a person link
 		this.addCommand({
@@ -90,6 +95,11 @@ module.exports = class AtPeople extends Plugin {
 		this.app.workspace.onLayoutReady(this.initialize)
 	}
 
+	onunload() {
+		// Remove the body class that gates the optional pill styling.
+		document.body.classList.remove('at-people-styled')
+	}
+
 	async loadSettings() {
 		const storedSettings = await this.loadData()
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, storedSettings)
@@ -97,6 +107,44 @@ module.exports = class AtPeople extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings || DEFAULT_SETTINGS)
+	}
+
+	// Toggle the body class that enables the optional built-in pill styling.
+	applyPillStyleClass = () => {
+		document.body.classList.toggle('at-people-styled', !!this.settings.enablePillStyle)
+	}
+
+	// Reading-view post-processor: add the `at-person` class and a
+	// `data-at-person` attribute to every internal link that points at a
+	// person file, so the links can be targeted from CSS snippets or themes.
+	markPersonLinks = (el, sourcePath) => {
+		for (const a of el.querySelectorAll('a.internal-link')) {
+			const linkpath = a.getAttribute('data-href') || a.getAttribute('href') || ''
+			const name = this.resolvePersonName(linkpath, sourcePath)
+			if (name) {
+				a.classList.add('at-person')
+				a.setAttribute('data-at-person', name)
+			}
+		}
+	}
+
+	// Resolve the person name a link target refers to, or false if it is not a
+	// person. Uses the resolved file when it exists, with a path-based fallback
+	// so links to not-yet-created person files are still tagged.
+	resolvePersonName = (linkpath, sourcePath) => {
+		if (!linkpath) return false
+		const dest = this.app.metadataCache.getFirstLinkpathDest(linkpath, sourcePath || '')
+		if (dest) return getPersonName(dest.path, this.settings)
+		// Unresolved link (the person file may not exist yet).
+		// Explicit links carry a full path we can match directly.
+		const direct = getPersonName(linkpath, this.settings)
+		if (direct) return direct
+		// Bare links carry only a name; only guess the people-folder path when
+		// the '@' prefix is required, otherwise the guess risks false positives.
+		if (this.settings.requireAtPrefix) {
+			return getPersonName(normalizeFolder(this.settings.peopleFolder) + linkpath + '.md', this.settings)
+		}
+		return false
 	}
 
 	updatePeopleMap = () => {
@@ -749,6 +797,22 @@ class AtPeopleSettingTab extends PluginSettingTab {
 					this.plugin.settings.requireAtPrefix = value
 					await this.plugin.saveSettings()
 					this.plugin.initialize()
+				})
+			)
+		new Setting(containerEl)
+			.setName('Style person links as pills')
+			.setDesc(multiLineDesc([
+			"Show @person links as tag-style pills in Reading view, using your theme's tag colors.",
+			"",
+			"Person links always get the 'at-person' class and a 'data-at-person' attribute, so you can write your own CSS even with this off."
+			]))
+			.addToggle(
+				toggle => toggle
+				.setValue(this.plugin.settings.enablePillStyle)
+				.onChange(async (value) => {
+					this.plugin.settings.enablePillStyle = value
+					await this.plugin.saveSettings()
+					this.plugin.applyPillStyleClass()
 				})
 			)
 	}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "at-people",
   "name": "At People",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Use the @ to create links to people files with smart fuzzy search, accent-insensitive matching, and backlink-based ranking.",
   "author": "Yass Fuentes",
   "authorUrl": "https://github.com/backmind/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-at-people",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Use the @ to create links to people files with smart fuzzy search, accent-insensitive matching, and backlink-based ranking.",
   "main": "main.js",
   "repository": {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,31 @@
+/*
+ * At People - styling for @person links.
+ *
+ * Person links in Reading (Preview) view always receive the `at-person`
+ * class and a `data-at-person="<name>"` attribute, so you can target them
+ * from your own CSS snippets or theme regardless of the setting below.
+ *
+ * The pill look here is opt-in: it only applies when "Style person links
+ * as pills" is enabled in the plugin settings, which adds the
+ * `at-people-styled` class to the document body. It reuses Obsidian's tag
+ * variables, so person links look like native tag pills but with @.
+ */
+
+body.at-people-styled .at-person {
+	background-color: var(--tag-background);
+	border: var(--tag-border-width) solid var(--tag-border-color);
+	border-radius: var(--tag-radius);
+	color: var(--tag-color);
+	font-size: var(--tag-size);
+	font-weight: var(--tag-weight);
+	padding: var(--tag-padding-y) var(--tag-padding-x);
+	text-decoration: var(--tag-decoration);
+	line-height: 1;
+}
+
+body.at-people-styled .at-person:hover {
+	background-color: var(--tag-background-hover);
+	border-color: var(--tag-border-color-hover);
+	color: var(--tag-color-hover);
+	text-decoration: var(--tag-decoration-hover);
+}


### PR DESCRIPTION
Closes #10

## What

Person links now expose styling hooks so they can be formatted with CSS (the request in #10: render them like tag pills, but with `@` instead of `#`).

In Reading (Preview) view, every person link gets:
- the CSS class `at-person`
- a `data-at-person="<name>"` attribute (the person's name, without the `@`)

Both are always added, so users can target person links from their own CSS snippet or theme.

It also adds an opt-in **Style person links as pills** setting (off by default). When enabled it applies a built-in tag-style pill look via a new `styles.css`, scoped under `body.at-people-styled` and reusing the theme's `--tag-*` variables.

## How

- A `registerMarkdownPostProcessor` walks the rendered `a.internal-link` nodes and tags the ones that resolve to (or point at) a person file, reusing the existing `getPersonName`. A path-based fallback covers links to not-yet-created person files.
- The pill toggle adds/removes `at-people-styled` on `document.body`; `onunload` cleans it up.

## Scope

Reading (Preview) view only. Live Preview (edit mode) is intentionally left out (it would need CodeMirror 6 decorations) and can be a follow-up.

## Testing

- Verified manually in Obsidian: person links receive `at-person` + `data-at-person` in Reading view, and the pill toggle applies/reverts the look.
- `node --check main.js` passes.

## Release note

New release asset: `styles.css` must be attached to the GitHub release alongside `main.js` and `manifest.json`. Version bumped to 1.6.0 in a separate `chore(release)` commit.

Generated with [Claude Code](https://claude.com/claude-code)
